### PR TITLE
updated sha256 for sonaric latest

### DIFF
--- a/sonaric.rb
+++ b/sonaric.rb
@@ -4,7 +4,7 @@ class Sonaric < Formula
   version "0.0.1"
 
   url_x64 = "https://storage.googleapis.com/sonaric-releases/nightly/macos/sonaric-darwin-latest.tar.gz"
-  sha256_x64 = "c385ae3c5ff0814029a29e86d76d4d8292ff7026fc6d35033cb576e1461ab97d"
+  sha256_x64 = "32c53fbd1569c5b4ea9406c2436e25f6af3466e2f8537fb6b48028748a943e90"
   url_arm64 = "https://storage.googleapis.com/sonaric-releases/nightly/macos/sonaric-arm-darwin-latest.tar.gz"
   sha256_arm64 = "24d3cd02550cc51140ec76c4ed39940f4e7d13ffe33a22c04e225dd575f562e1"
 


### PR DESCRIPTION
```
brew install monk-io/sonaric/sonaric
==> Tapping monk-io/sonaric
Cloning into '/usr/local/Homebrew/Library/Taps/monk-io/homebrew-sonaric'...
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 9 (delta 1), reused 5 (delta 1), pack-reused 0
Receiving objects: 100% (9/9), done.
Resolving deltas: 100% (1/1), done.
Tapped 1 formula (15 files, 10.0KB).
==> Downloading https://formulae.brew.sh/api/formula.jws.json
################################################################################################################################################################################### 100.0%
==> Fetching monk-io/sonaric/sonaric
==> Downloading https://storage.googleapis.com/sonaric-releases/nightly/macos/sonaric-darwin-latest.tar.gz
################################################################################################################################################################################### 100.0%
Error: sonaric: SHA256 mismatch
Expected: c385ae3c5ff0814029a29e86d76d4d8292ff7026fc6d35033cb576e1461ab97d
  Actual: 32c53fbd1569c5b4ea9406c2436e25f6af3466e2f8537fb6b48028748a943e90
    File: /Users/artem/Library/Caches/Homebrew/downloads/d15c8442c91d9da82d562473e6011b8666703a17ee166c29402a1ea7b40d1d44--sonaric-darwin-latest.tar.gz
To retry an incomplete download, remove the file above.
```