### PR TITLE
[CORE-2001] sonaric runtime

### DIFF
--- a/sonaric-runtime.rb
+++ b/sonaric-runtime.rb
@@ -1,0 +1,17 @@
+class SonaricRuntime < Formula
+  desc "Sonaric Network Runtime"
+  homepage "https://sonaric.xyz"
+  version "0.0.1"
+
+  depends_on "podman" => :recommended
+  url "https://github.com/monk-io/homebrew-sonaric.git", branch: "main"
+
+  def install
+    bin.install "sonaric-runtime.sh" => "sonaric-runtime"
+  end
+
+  service do
+    run [opt_bin/"sonaric-runtime"]
+    keep_alive true
+  end
+end

--- a/sonaric-runtime.sh
+++ b/sonaric-runtime.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+while true; do
+  case $(podman machine inspect --format '{{.State}}') in
+    stopped)
+      podman machine start
+      ;;
+    running)
+      echo "Machine is already running"
+      ;;
+    *)
+      podman machine init --now --rootful
+      ;;
+  esac
+
+  # Recheck machine each 5 min
+  sleep 300
+done

--- a/sonaric.rb
+++ b/sonaric.rb
@@ -31,4 +31,9 @@ class Sonaric < Formula
       sonaric machine upgrade
     EOS
   end
+
+  service do
+    run [opt_bin/"sonaricd"]
+    keep_alive true
+  end
 end


### PR DESCRIPTION
sonaric runtime is a brew service witch help us to init default podman machine 

```
 brew services start sonaric-runtime
==> Successfully started `sonaric-runtime` (label: homebrew.mxcl.sonaric-runtime)
```

```
brew services info sonaric-runtime
sonaric-runtime (homebrew.mxcl.sonaric-runtime)
Running: ✔
Loaded: ✔
Schedulable: ✘
User: artem
PID: 2241
```