### PR TITLE
fix: correct uninstall podman

### DIFF
--- a/installer/uninstall.sh
+++ b/installer/uninstall.sh
@@ -80,10 +80,6 @@ fi
 if [ "${HOMEBREW}" != "" ]; then
   log "Sonaric service stopping..."
   ${HOMEBREW} services stop sonaric
-  sleep 3
-
-  log "Sonaric uninstalling..."
-  ${HOMEBREW} uninstall -f --ignore-dependencies sonaric
 fi
 
 if [ "${PODMAN}" != "" ]; then
@@ -96,6 +92,9 @@ if [ "${PODMAN}" != "" ]; then
 fi
 
 if [ "${HOMEBREW}" != "" ]; then
+  log "Sonaric uninstalling..."
+  ${HOMEBREW} uninstall -f --ignore-dependencies sonaric
+
   log "Podman uninstalling..."
   ${HOMEBREW} uninstall -f --ignore-dependencies podman
 fi


### PR DESCRIPTION
Fix for:
```
Podman machine stopping...
bash: line 90: /usr/local/bin/podman: No such file or directory
Podman machine removing...
bash: line 94: /usr/local/bin/podman: No such file or directory
Podman uninstalling...
```