### PR TITLE
sonaric-runtime: downloads only sonaric-runtime.sh instead of cloning the repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: sha
+sha:
+	shasum -a 256 sonaric-entrypoint.sh
+	shasum -a 256 sonaric-runtime.sh

--- a/sonaric-runtime.rb
+++ b/sonaric-runtime.rb
@@ -1,13 +1,22 @@
 class SonaricRuntime < Formula
-  desc "Sonaric Network Runtime: the AI-powered backbone for all blockchains."
+  desc "Sonaric Network Runtime: the runtime for the Sonaric Network daemon."
   homepage "https://sonaric.xyz"
   version "0.0.1"
 
   depends_on "podman"
-  url "https://github.com/monk-io/homebrew-sonaric.git", branch: "main"
+
+  resource "sonaric-runtime" do
+    sha256 "55a830fbd30bf7d8a9da8b614667cd19c7a0946fbccdb19bde3f4fa8a419b56f"
+    url "https://raw.githubusercontent.com/monk-io/homebrew-sonaric/HEAD/sonaric-runtime.sh"
+  end
 
   def install
-    bin.install "sonaric-runtime.sh" => "sonaric-runtime"
+    resources.each do |r|
+      case r.name
+      when "sonaric-runtime"
+        bin.install r.cached_download => "sonaric-runtime"
+      end
+    end
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
# Sonaric runtime

downloads only needed resources:
 -  sonaric-runtime.sh

instead of cloning the repository 