### PR TITLE
sonaric-entrypoint: downloads only sonaric-entrypoint.sh instead of cloning the repository

### DIFF
--- a/sonaric.rb
+++ b/sonaric.rb
@@ -8,11 +8,7 @@ class Sonaric < Formula
   url_arm64 = "https://storage.googleapis.com/sonaric-releases/stable/macos/sonaric-arm-darwin-v0.1.3.tar.gz"
   sha256_arm64 = "584d7da94964120510edbc8b9b5f853315b7bafe3fdc1aa0e5c589943a86a40b"
 
-  depends_on "podman" => :recommended
-
-  resource "sonaric-entrypoint" do
-    url "https://github.com/monk-io/homebrew-sonaric.git", branch: "main"
-  end
+  depends_on "monk-io/sonaric/sonaric-runtime"
 
   if Hardware::CPU.intel?
     sha256 sha256_x64
@@ -22,15 +18,21 @@ class Sonaric < Formula
     url url_arm64
   end
 
+  resource "sonaric-entrypoint" do
+    sha256 "db76d91e488f2285f4a4bbab75523677d3c34ea6c28ae0dfe99e44e31aeccd66"
+    url "https://raw.githubusercontent.com/monk-io/homebrew-sonaric/HEAD/sonaric-entrypoint.sh"
+  end
+
   def install
+    bin.install "sonaric" => "sonaric"
+    bin.install "sonaricd" => "sonaricd"
+
     resources.each do |r|
       case r.name
       when "sonaric-entrypoint"
-        bin.install r.cached_download/"sonaric-entrypoint.sh" => "sonaric-entrypoint"
+        bin.install r.cached_download => "sonaric-entrypoint"
       end
     end
-    bin.install "sonaric" => "sonaric"
-    bin.install "sonaricd" => "sonaricd"
   end
 
   def caveats; <<~EOS

--- a/sonaric.rb.template
+++ b/sonaric.rb.template
@@ -8,11 +8,7 @@ class Sonaric < Formula
   url_arm64 = "_BREW_ARM_URL"
   sha256_arm64 = "_BREW_ARM_SHA256"
 
-  depends_on "podman" => :recommended
-
-  resource "sonaric-entrypoint" do
-    url "https://github.com/monk-io/homebrew-sonaric.git", branch: "main"
-  end
+  depends_on "monk-io/sonaric/sonaric-runtime"
 
   if Hardware::CPU.intel?
     sha256 sha256_x64
@@ -22,15 +18,21 @@ class Sonaric < Formula
     url url_arm64
   end
 
+  resource "sonaric-entrypoint" do
+    sha256 "db76d91e488f2285f4a4bbab75523677d3c34ea6c28ae0dfe99e44e31aeccd66"
+    url "https://raw.githubusercontent.com/monk-io/homebrew-sonaric/HEAD/sonaric-entrypoint.sh"
+  end
+
   def install
+    bin.install "sonaric" => "sonaric"
+    bin.install "sonaricd" => "sonaricd"
+
     resources.each do |r|
       case r.name
       when "sonaric-entrypoint"
-        bin.install r.cached_download/"sonaric-entrypoint.sh" => "sonaric-entrypoint"
+        bin.install r.cached_download => "sonaric-entrypoint"
       end
     end
-    bin.install "sonaric" => "sonaric"
-    bin.install "sonaricd" => "sonaricd"
   end
 
   def caveats; <<~EOS


### PR DESCRIPTION
# Sonaric entrypoint

downloads only needed resources:
 -  sonaric-entrypoint.sh

instead of cloning the repository 

monk-io/sonaric/sonaric depends on monk-io/sonaric/sonaric-runtime
Used sonaric-runtime service instead of podman machine directly