### PR TITLE
[fix] sonaric-entrypoint: run sonaricd with truncate-log flag

### DIFF
--- a/sonaric-entrypoint.sh
+++ b/sonaric-entrypoint.sh
@@ -169,7 +169,7 @@ daemon_shutdown(){
 
 # Start sonaric daemon
 log "Sonaric daemon starting..."
-sonaricd -m "unix://${CR_PATH}" &
+sonaricd --truncate-log -m "unix://${CR_PATH}" &
 SONARICD_PID=$!
 
 log "Sonaric daemon started (PID=${SONARICD_PID})"


### PR DESCRIPTION
`sonaricd --truncate-log`

```
--truncate-log                      Truncate DB log files when necessary
```